### PR TITLE
Fixed branch specification on versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 [
   {"required_api_version": "^1.0.0", "commit": "release-for-api-v1"},
   {"required_api_version": "^2.0.0", "commit": "release-for-api-v2"},
-  {"required_api_version": "^2.3.1", "commit": "master"}
+  {"required_api_version": "^2.3.1", "commit": "main"}
 ]


### PR DESCRIPTION
Unable to add extension to uLauncher, most likely due to incorrect branch name indicated in the versions.json file.

Reference:
https://github.com/Ulauncher/Ulauncher/issues/738